### PR TITLE
Support "multiple roots" by returning directories with a absolute paths

### DIFF
--- a/src/FileEntry.ts
+++ b/src/FileEntry.ts
@@ -44,7 +44,6 @@ export class FileEntry {
 		this._metadata = { ...(optionalMetadata || {}) }
 		this._depth = parent ? parent.depth + 1 : 0
 		if (parent && typeof fileName === 'string') {
-			fileName = root.pathfx.basename(fileName)
 			this._fileName = fileName
 		}
 		FileEntry.idToFileEntry.set(this._uid, this)
@@ -78,7 +77,11 @@ export class FileEntry {
 			throw new Error(`orphaned/detached FileEntries don't have path (except Root)`)
 		}
 		if (!this.resolvedPathCache) {
-			this.resolvedPathCache = this.root.pathfx.join(this.parent.path, this.fileName)
+			if (this.root.pathfx.isRelative(this.fileName)) {
+				this.resolvedPathCache = this.root.pathfx.join(this.parent.path, this.fileName)
+			} else {
+				this.resolvedPathCache = this.fileName
+			}
 		}
 		return this.resolvedPathCache
 	}


### PR DESCRIPTION
This is a breaking change, as fileName is no longer guaranteed to be a basename, and if implementations of IBasicFileSystemHost return absolute paths as names, all fileNames will instantly become excessively long. Your call whether or not that's rare enough to merge this. see #14